### PR TITLE
Fix tailwind

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -51,5 +51,5 @@
       "skipClassAttribute": false
     }
   },
-  "ignorePatterns": ["dist"]
+  "ignorePatterns": ["dist", "postcss.config.cjs"]
 }

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>투두막</title>
+    <link rel="stylesheet" href="./dist/assets/main-C2gzns86.css" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## 작업 내용
1. typescript 기반으로 진행되는 eslint 검사에서 `postcss.config.cjs`파일을 제외시켰습니다.
2. build 작업 후에 변환된 css 파일을 `index.html`에 적용시켰습니다.