### PR TITLE
Set cd

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,8 +21,3 @@ jobs:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
-
-      - name: Print new tag, new version, and previous tag
-        run: |
-          echo "New tag: ${{ steps.tag_version.outputs.new_tag }}"
-          echo "New version: ${{ steps.tag_version.outputs.new_version }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,13 +16,16 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 브랜치 이름 제거
-        id: sanitize_tag
-        run: echo "::set-output name=sanitized_tag::$(echo '${{ steps.tag_version.outputs.new_tag }}' | sed -E 's/-.*//')"
-
       - name: release 업데이트
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ steps.sanitize_tag.outputs.sanitized_tag }}
-          name: Release ${{ steps.sanitize_tag.outputs.sanitized_tag }}
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
+
+      - name: Print new tag, new version, and previous tag
+        run: |
+          echo "New Tag: ${{ steps.tag_version.outputs.new_tag }}"
+          echo "New Version: ${{ steps.tag_version.outputs.new_version }}"
+          echo "Previous Tag: ${{ steps.tag_version.outputs.previous_tag }}"
+          echo "Changelog: ${{ steps.tag_version.outputs.changelog }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,9 +16,13 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 브랜치 이름 제거
+        id: sanitize_tag
+        run: echo "::set-output name=sanitized_tag::$(echo '${{ steps.tag_version.outputs.new_tag }}' | sed -E 's/-.*//')"
+
       - name: release 업데이트
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ steps.tag_version.outputs.new_version }}
-          name: ${{ steps.tag_version.outputs.new_version }}
+          tag: ${{ steps.sanitize_tag.outputs.sanitized_tag }}
+          name: Release ${{ steps.sanitize_tag.outputs.sanitized_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,46 @@
+name: release
+
+on:
+  push:
+    branches:
+      - master
+      - set-cd-release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
+
+      - name: dependencies 설치
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Zip dist folder
+        run: zip -r dist.zip dist/
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: todomark.zip
+
+      - name: Upload release
+        uses: actions/upload-artifact@v3
+        with:
+          name: todomark
+          path: todomark.zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - set-cd-release
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,6 @@ jobs:
       - name: release 업데이트
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          tag: ${{ steps.tag_version.outputs.new_version }}
+          name: ${{ steps.tag_version.outputs.new_version }}
           body: ${{ steps.tag_version.outputs.changelog }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,5 @@ jobs:
 
       - name: Print new tag, new version, and previous tag
         run: |
-          echo "New Tag: ${{ steps.tag_version.outputs.new_tag }}"
-          echo "New Version: ${{ steps.tag_version.outputs.new_version }}"
-          echo "Previous Tag: ${{ steps.tag_version.outputs.previous_tag }}"
-          echo "Changelog: ${{ steps.tag_version.outputs.changelog }}"
+          echo "New tag: ${{ steps.tag_version.outputs.new_tag }}"
+          echo "New version: ${{ steps.tag_version.outputs.new_version }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,40 +7,18 @@ on:
       - set-cd-release
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [20]
-
     steps:
-      - uses: actions/checkout@v4
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - name: Github의 최신 tag 받아오기
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.1
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: dependencies 설치
-        run: pnpm install
-
-      - name: Build
-        run: pnpm build
-
-      - name: Zip dist folder
-        run: zip -r dist.zip dist/
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
+      - name: release 업데이트
+        uses: ncipollo/release-action@v1
         with:
-          files: todomark.zip
-
-      - name: Upload release
-        uses: actions/upload-artifact@v3
-        with:
-          name: todomark
-          path: todomark.zip
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
## 작업 내용
1. [github-tag-action](https://github.com/mathieudutour/github-tag-action?tab=readme-ov-file)을 이용하여 태그 이름 관리를 합니다.
2. master 브랜치에 push 이벤트가 발생할 경우 소스코드를 [release-action](https://github.com/ncipollo/release-action)을 이용하여 Release에 업데이트합니다.
3. 시멘틱 버저닝 bumping 규칙은 다음과 같습니다.
    <table>
    <tr>
    <td> Commit message </td> <td> Release type </td>
    </tr>
    <tr>
    <td>
    
    ```
    fix(pencil): stop graphite breaking when too much pressure applied
    ```
    
    </td>
    <td>Patch Release</td>
    </tr>
    <tr>
    <td>
    
    ```
    feat(pencil): add 'graphiteWidth' option
    ```
    
    </td>
    <td>Minor Release</td>
    </tr>
    <tr>
    <td>
    
    ```
    perf(pencil): remove graphiteWidth option
    
    BREAKING CHANGE: The graphiteWidth option has been removed.
    The default graphite width of 10mm is always used for performance reasons.
    ```
    
    </td>
    <td>Major Release</td>
    </tr>
    </table>
4. release 페이지 내용으로는 commit 메세지를 기반으로 변동사항들이 작성됩니다.